### PR TITLE
fix: Order asc in users in pending payments

### DIFF
--- a/resources/views/assistance/assistance.blade.php
+++ b/resources/views/assistance/assistance.blade.php
@@ -122,7 +122,7 @@
 <script>
     $(document).ready(function () {
         $('#dataTable').DataTable({
-            order: [1, 'desc'],
+            order: [0, 'asc'],
         })
     })
 </script>

--- a/resources/views/assistance/todayAssistances.blade.php
+++ b/resources/views/assistance/todayAssistances.blade.php
@@ -92,7 +92,7 @@
 <script>
     $(document).ready(function () {
         $('#dataTable').DataTable({
-            order: [1, 'desc'],
+            order: [0, 'asc'],
         })
     })
 </script>

--- a/resources/views/payment/pending.blade.php
+++ b/resources/views/payment/pending.blade.php
@@ -110,7 +110,7 @@
 <script>
     $(document).ready(function () {
         $('#dataTable').DataTable({
-            order: [[2, 'desc']],
+            order: [[0, 'asc']],
         })
     })
 </script>

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -137,7 +137,7 @@
                             @foreach ($userPayments as $payment)  
                                 <tr>                               
                                     <td>${{ $payment->price }}</td>
-                                    <td>{{ $payment->date->format('d/m/Y') }}</td>
+                                    <td data-sort="{{ strtotime($payment->date) }}">{{ $payment->date->format('d/m/Y') }}</td>
                                     <td>{{ $payment->userSubscription->subscription->name }}</td>
                                     <td><h5><span class="badge badge-pill badge-{{$payment->paymentStatus->color}}">{{ $payment->paymentStatus->name }}</span></h5></td>
                                     <td>
@@ -182,7 +182,7 @@
                             @foreach ($userSubscriptions as $userSubscription)
                                 <tr>                               
                                     <td>{{ $userSubscription->subscription->name }}</td>
-                                    <td data-order="Ymd">{{ $userSubscription->user_subscription_status_updated_at->format('d/m/Y') }}</td>
+                                    <td data-sort="{{ strtotime($payment->date) }}">{{ $userSubscription->user_subscription_status_updated_at->format('d/m/Y') }}</td>
                                     <td><h5><span class="badge badge-pill badge-{{$userSubscription->status->color}}">{{ $userSubscription->status->name }}</td>                                
                                 </tr>
                             @endforeach

--- a/resources/views/profile/usersWhoLeft.blade.php
+++ b/resources/views/profile/usersWhoLeft.blade.php
@@ -94,7 +94,7 @@
 <script>
     $(document).ready(function () {
         $('#dataTable').DataTable({
-            order: [3, 'desc'],
+            order: [0, 'asc'],
         })
     })
 </script>


### PR DESCRIPTION
Pedido por el sensei, ordenar por apellido en los pendientes.

Ya que estamos y para evitar futuras mejoras, lo cambie en varias vistas porque fijo lo pide.